### PR TITLE
fix(files-service): Add cwd to the findAll method

### DIFF
--- a/src/services/utils/FilesService.js
+++ b/src/services/utils/FilesService.js
@@ -83,6 +83,11 @@ class FileService{
          * @description this is easier to deal with files this way 
          */
         const fileModels = filePaths.map(filePath => {
+            /**
+             * @step add cwd to the path 
+             * @desc this will complain sometimes so it's safer with the full path
+             */
+            filePath = path.join(process.cwd(), filePath); 
             return new FileModel(filePath);
         });
 


### PR DESCRIPTION
so that the full path is appended with path.join or else `build` will complain sometimes